### PR TITLE
fix: fixed next-auth import

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -3,7 +3,7 @@ import NextAuth from "next-auth";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import GoogleProvider from "next-auth/providers/google";
 import prisma from "../../../lib/prisma";
-import { EmailConfig } from "next-auth/src/providers/email";
+import { EmailConfig } from "next-auth/providers/email";
 import { sendEmail } from "../../../lib/email-providers";
 import { sha256 } from "js-sha256";
 


### PR DESCRIPTION
There's a typo in one of the `next-auth` import statements: an attempt to import from `next-auth/src/providers/email` instead of `next-auth/providers/email`. That (sometimes?) causes `yarn build` to fail with the following eror:

```bash
./node_modules/next-auth/src/core/errors.ts:11:11
Type error: No overload matches this call.
Overload 1 of 2, '(message?: string, options?: ErrorOptions): Error', gave the following error.
Argument of type 'string | Error' is not assignable to parameter of type 'string'.
Type 'Error' is not assignable to type 'string'.
Overload 2 of 2, '(message?: string): Error', gave the following error.
Argument of type 'string | Error' is not assignable to parameter of type 'string'.
Type 'Error' is not assignable to type 'string'.

9 | constructor(error: Error | string) {
10 | // Support passing error or string

11 | super((error as Error)?.message ?? error)
| ^
12 | this.name = "UnknownError"
13 | this.code = (error as any).code
14 | if (error instanceof Error) {
error Command failed with exit code 1.
```

Also, for extra context: https://github.com/nextauthjs/next-auth/discussions/7386